### PR TITLE
Fixing the error caused by passing the QByteArray to mask method

### DIFF
--- a/QtWebsocket/QWsSocket.cpp
+++ b/QtWebsocket/QWsSocket.cpp
@@ -123,7 +123,8 @@ void QWsSocket::close( ECloseStatusCode closeStatusCode, QString reason )
 					{
 						if ( ! serverSideSocket )
 						{
-							reason = QWsSocket::mask( reason.toUtf8(), maskingKey );
+							QByteArray data = reason.toUtf8();							
+							reason = QWsSocket::mask( data, maskingKey );
 						}
 						body.append( reason );
 					}


### PR DESCRIPTION
The error thrown is as follows:

QWsSocket.h: In constructor ‘QWsSocket::QWsSocket(QObject_, QTcpSocket_, EWebsocketVersion)’:
QWsSocket.h:148:13: warning: ‘QWsSocket::maskingKey’ will be initialized after [-Wreorder]
QWsSocket.h:138:7: warning:   ‘bool QWsSocket::serverSideSocket’ [-Wreorder]
QWsSocket.cpp:13:1: warning:   when initialized here [-Wreorder]
QWsSocket.cpp: In member function ‘virtual void QWsSocket::close(QWsSocket::ECloseStatusCode, QString)’:
QWsSocket.cpp:126:62: error: no matching function for call to ‘QWsSocket::mask(QByteArray, QByteArray&)’
QWsSocket.cpp:126:62: note: candidate is:
QWsSocket.h:161:20: note: static QByteArray QWsSocket::mask(QByteArray&, QByteArray&)
QWsSocket.h:161:20: note:   no known conversion for argument 1 from ‘QByteArray’ to ‘QByteArray&’

The reason is with the call to QWsSocket::mask(), the first argument is passed as a temporary and which can't be converted into reference. Hence the error is thrown. Fixing it by creating a local QByteArray data and then passing this as the first argument to mask to fix the error
