### PR TITLE
Update QtWebsocket.pro

### DIFF
--- a/QtWebsocket.pro
+++ b/QtWebsocket.pro
@@ -6,3 +6,8 @@ SUBDIRS += \
     Example/Server \
     Example/ServerThreaded \
     AutobahnTestSuite
+
+Client.depends = QtWebsocket
+Server.depends = QtWebsocket
+ServerThreaded.depends = QtWebsocket
+AutobahnTestSuite.depends = QtWebsocket


### PR DESCRIPTION
Fix for issue #23. Added list of dependencies in project file for parallel compilation on multicore systems("make" with "-j3" parameter).
